### PR TITLE
Fix Multiline Clipboard

### DIFF
--- a/projects/console-forge/src/lib/components/console-toolbar-default/console-toolbar-default.component.html
+++ b/projects/console-forge/src/lib/components/console-toolbar-default/console-toolbar-default.component.html
@@ -224,12 +224,12 @@
             <div class="dialog-section">
                 <h2>Remote Clipboard Content</h2>
                 <form (submit)="handleClipboardCopyLastText(consoleLastClipboardText.value)">
-                    <fieldset role="group">
-                        <input type="text" id="textFromConsoleClipboard" name="textFromConsoleClipboard"
+                    <fieldset>
+                        <textarea id="textFromConsoleClipboard" name="textFromConsoleClipboard" rows="4"
                             class="clipboard-text" aria-describedby="textFromConsoleClipboard-helper"
                             aria-label="Clipboard text" disabled
                             [value]="consoleContext().clipboard.consoleClipboardText()"
-                            placeholder="Text on the remote will appear here" #consoleLastClipboardText>
+                            placeholder="Text on the remote will appear here" #consoleLastClipboardText></textarea>
                         <button type="submit" [disabled]="!consoleLastClipboardText.value">Copy</button>
                     </fieldset>
                     @if(consoleContext().userSettings.settings().console.allowCopyToLocalClipboard &&

--- a/projects/console-forge/src/lib/components/console-toolbar-default/console-toolbar-default.component.html
+++ b/projects/console-forge/src/lib/components/console-toolbar-default/console-toolbar-default.component.html
@@ -228,8 +228,7 @@
                         <textarea id="textFromConsoleClipboard" name="textFromConsoleClipboard" rows="4"
                             class="clipboard-text" aria-describedby="textFromConsoleClipboard-helper"
                             aria-label="Clipboard text" disabled
-                            [value]="consoleContext().clipboard.consoleClipboardText()"
-                            placeholder="Text on the remote will appear here" #consoleLastClipboardText></textarea>
+                            placeholder="Text on the remote will appear here" #consoleLastClipboardText>{{ consoleContext().clipboard.consoleClipboardText() }}</textarea>
                         <button type="submit" [disabled]="!consoleLastClipboardText.value">Copy</button>
                     </fieldset>
                     @if(consoleContext().userSettings.settings().console.allowCopyToLocalClipboard &&

--- a/projects/console-forge/src/lib/components/console-toolbar-default/console-toolbar-default.component.html
+++ b/projects/console-forge/src/lib/components/console-toolbar-default/console-toolbar-default.component.html
@@ -211,9 +211,9 @@
             <div class="dialog-section">
                 <h2>Send Text to Remote Clipboard</h2>
                 <form (submit)="handleSendClipboardText($event, clipboardText.value)">
-                    <fieldset role="group">
-                        <input type="text" class="clipboard-text" aria-label="Clipboard text"
-                            placeholder="Enter text to send to the remote clipboard" #clipboardText autofocus>
+                    <fieldset>
+                        <textarea class="clipboard-text" aria-label="Clipboard text" rows="4"
+                            placeholder="Enter text to send to the remote clipboard" #clipboardText autofocus></textarea>
                         <button type="submit"
                             [disabled]="!clipboardText.value || !consoleContext().state.isConnected">Send</button>
                     </fieldset>
@@ -257,10 +257,10 @@
             <div class="dialog-section">
                 <h2>Send Keystrokes to Console</h2>
                 <form (submit)="handleSendKeyboardInput($event, keyboardInputText())">
-                    <fieldset role="group">
-                        <input type="text" id="keyboardInputText" name="keyboardInputText" class="keyboard-text"
+                    <fieldset>
+                        <textarea id="keyboardInputText" name="keyboardInputText" class="keyboard-text" rows="4"
                             aria-label="Keyboard text" placeholder="Enter text to send as keyboard input to the console"
-                            autofocus [(ngModel)]="keyboardInputText">
+                            autofocus [(ngModel)]="keyboardInputText"></textarea>
                         <button type="submit"
                             [disabled]="!keyboardInputText() || !consoleContext().state.isConnected">Send</button>
                     </fieldset>

--- a/projects/console-forge/src/lib/components/console-toolbar-default/console-toolbar-default.component.html
+++ b/projects/console-forge/src/lib/components/console-toolbar-default/console-toolbar-default.component.html
@@ -227,7 +227,7 @@
                     <fieldset>
                         <textarea id="textFromConsoleClipboard" name="textFromConsoleClipboard" rows="4"
                             class="clipboard-text" aria-describedby="textFromConsoleClipboard-helper"
-                            aria-label="Clipboard text" disabled
+                            aria-label="Clipboard text" readonly
                             placeholder="Text on the remote will appear here" #consoleLastClipboardText>{{ consoleContext().clipboard.consoleClipboardText() }}</textarea>
                         <button type="submit" [disabled]="!consoleLastClipboardText.value">Copy</button>
                     </fieldset>


### PR DESCRIPTION
Changes clipboard and keyboard UI elements to multi-line textareas to preserve multi-line copy/paste