### PR TITLE
Fix angular dependency

### DIFF
--- a/projects/console-forge/package-lock.json
+++ b/projects/console-forge/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@cmusei/console-forge",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@cmusei/console-forge",
-      "version": "0.20.7",
+      "version": "0.21.4",
       "dependencies": {
         "@picocss/pico": "^2.1.1",
         "tslib": "^2.3.0"
@@ -16,8 +16,8 @@
         "raw-loader": "^4.0.2"
       },
       "peerDependencies": {
-        "@angular/common": "^21.2.5",
-        "@angular/core": "^21.2.5",
+        "@angular/common": "^19.2.0 || ^20.0.0 || ^21.0.0",
+        "@angular/core": "^19.2.0 || ^20.0.0 || ^21.0.0",
         "@novnc/novnc": "^1.4.0"
       }
     },

--- a/projects/console-forge/package-lock.json
+++ b/projects/console-forge/package-lock.json
@@ -16,8 +16,8 @@
         "raw-loader": "^4.0.2"
       },
       "peerDependencies": {
-        "@angular/common": "^19.2.0 || ^20.0.0 || ^21.0.0",
-        "@angular/core": "^19.2.0 || ^20.0.0 || ^21.0.0",
+        "@angular/common": ">=19.2.0",
+        "@angular/core": ">=19.2.0",
         "@novnc/novnc": "^1.4.0"
       }
     },

--- a/projects/console-forge/package.json
+++ b/projects/console-forge/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cmusei/console-forge",
-  "version": "0.21.3",
+  "version": "0.21.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/cmu-sei/console-forge.git"
@@ -9,8 +9,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common": "^21.2.5",
-    "@angular/core": "^21.2.5",
+    "@angular/common": "^19.2.0 || ^20.0.0 || ^21.0.0",
+    "@angular/core": "^19.2.0 || ^20.0.0 || ^21.0.0",
     "@novnc/novnc": "^1.4.0"
   },
   "dependencies": {

--- a/projects/console-forge/package.json
+++ b/projects/console-forge/package.json
@@ -9,8 +9,8 @@
     "access": "public"
   },
   "peerDependencies": {
-    "@angular/common": "^19.2.0 || ^20.0.0 || ^21.0.0",
-    "@angular/core": "^19.2.0 || ^20.0.0 || ^21.0.0",
+    "@angular/common": ">=19.2.0",
+    "@angular/core": ">=19.2.0",
     "@novnc/novnc": "^1.4.0"
   },
   "dependencies": {


### PR DESCRIPTION
- A previous commit bumped the dependent angular version too high. The library now allows ng 19, 20, and 21 as peer deps